### PR TITLE
Update protobuf library package name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ streaming.
 
 Because [Code Review 9102043](https://codereview.appspot.com/9102043/) is
 destined to never be merged into mainline (i.e., never be promoted to formal
-[goprotobuf features](https://code.google.com/p/goprotobuf)), this repository
+[goprotobuf features](https://github.com/golang/protobuf)), this repository
 will live here in the wild.
 
 # Documentation

--- a/ext/all_test.go
+++ b/ext/all_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"testing/quick"
 
-	. "code.google.com/p/goprotobuf/proto"
-	. "code.google.com/p/goprotobuf/proto/testdata"
+	. "github.com/golang/protobuf/proto"
+	. "github.com/golang/protobuf/proto/testdata"
 )
 
 func TestWriteDelimited(t *testing.T) {

--- a/ext/decode.go
+++ b/ext/decode.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"io"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 )
 
 var errInvalidVarint = errors.New("invalid varint32 encountered")

--- a/ext/encode.go
+++ b/ext/encode.go
@@ -18,7 +18,7 @@ import (
 	"encoding/binary"
 	"io"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 )
 
 // WriteDelimited encodes and dumps a message to the provided writer prefixed

--- a/ext/fixtures_test.go
+++ b/ext/fixtures_test.go
@@ -1,5 +1,5 @@
 // Copyright 2010 The Go Authors.  All rights reserved.
-// http://code.google.com/p/goprotobuf/
+// http://github.com/golang/protobuf/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -30,11 +30,11 @@
 package ext
 
 import (
-	. "code.google.com/p/goprotobuf/proto"
-	. "code.google.com/p/goprotobuf/proto/testdata"
+	. "github.com/golang/protobuf/proto"
+	. "github.com/golang/protobuf/proto/testdata"
 )
 
-// FROM https://code.google.com/p/goprotobuf/source/browse/proto/all_test.go.
+// FROM https://github.com/golang/protobuf/blob/master/proto/all_test.go.
 
 func initGoTestField() *GoTestField {
 	f := new(GoTestField)


### PR DESCRIPTION
The Golang protocol buffer library has now moved to GitHub:

https://github.com/golang/protobuf

Although "go get"-ing the old package name still works, moving
everything to the new one will make vendoring cleaner.