### PR TITLE
Support Go Modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: go
 
 go:
-        - 1.5
-        - 1.6
+        - 1.9.x
+        - 1.10.x
+        - 1.11.x
         - tip
 
 script: make -f Makefile.TRAVIS

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/matttproud/golang_protobuf_extensions
+
+go 1.9
+
+require (
+	github.com/golang/protobuf v1.2.0
+	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
+github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
+golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
Hello,

Please consider supporting [Go Modules], the new packaging standard that will be adopted fully in Go 1.12. Experimental support is in Go 1.11 and the new module paths are supported in Go 1.9.7+ and Go 1.10.3+ in a read-only manner for backwards compatibility with all supported versions of Go.

Because this library is still below version 2, already uses semver compatible tags, and has few dependencies, the [`go.mod`] file is fairly simple.

Note that I set the language version go 1.9 in the mod file because 1.9.7 is the earliest version with partial support for reading the `go.mod` file (earlier versions will keep working as they always have and won't read the go.mod file). I also took the liberty of bumping the versions you test against in Travis to include more recent versions, and the most recent patch release of each version. I wasn't sure what the earliest syntax and APIs you actually wanted to support was, so I just picked 1.9 (although I think 1.10 is the earliest version still supported by the Go team). Let me know if this was wrong or you'd like it changed.

Thank you for your consideration.

[Go Modules]: https://github.com/golang/go/wiki/Modules
[`go.mod`]: https://tip.golang.org/cmd/go/#hdr-The_go_mod_file