### PR TITLE
Retract v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.5
+
+Retract the v1.0.3 version.
+
 ## v1.0.4
 
 **Summary**: This is an emergency re-tag of v1.0.2 since v1.0.3 broke API

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/matttproud/golang_protobuf_extensions
 
-go 1.9
+go 1.16
 
 require (
 	github.com/golang/protobuf v1.2.0
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect
 )
+
+retract v1.0.3


### PR DESCRIPTION
* Retract the broken v1.0.3 tag.
* Bump the Go version to support `retract` directive.